### PR TITLE
Re-Add support for python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+install:
+  - ./configure
+script:
+  - tmp/bin/pytest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,19 @@
 Release notes
 -------------
+### Upcoming Version
+
+*2020-10-08* -- Add support for both python 2 + 3
+*2020-10-08* -- Add CI support for python 2 + 3
+
+### Version 20.10
+
+* Minimal fixes needed for proper release
+
+### Version 20.09.30
+
+*2020-09-25* -- Update to PEP 517/518 development practices
+*2020-09-25* -- Add some minimal documentation
+
 ### Version 20.09
 
 *2020-09-24* -- Initial release.

--- a/configure
+++ b/configure
@@ -18,7 +18,7 @@ fi
 
 
 if [[ "$PYTHON_EXE" == "" ]]; then
-    PYTHON_EXE=python3
+    PYTHON_EXE=python
 fi
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 50", "wheel", "setuptools_scm[toml] >= 4"]
+requires = ["setuptools >= 44", "wheel", "setuptools_scm[toml] >= 4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages=find:
 include_package_data = true
 zip_safe = false
 install_requires =
-    backports.os == 0.1.1
+    backports.os == 0.1.1; python_version < "3"
     attrs >= 18.1, !=20.1.0
     click >= 6.0.0
     text_unidecode >= 1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ packages=find:
 include_package_data = true
 zip_safe = false
 install_requires =
+    backports.os == 0.1.1
     attrs >= 18.1, !=20.1.0
     click >= 6.0.0
     text_unidecode >= 1.0
@@ -40,5 +41,5 @@ where=src
 [options.extras_require]
 testing =
     # upstream
-    pytest >= 6
-    pytest-xdist >= 2
+    pytest >= 4
+    pytest-xdist >= 1


### PR DESCRIPTION
* Update configure script to use `python` by default
* Lower build dependency version requirements to support python2
* Lower test dependency version requirements to support python2
* Re-add backports.os as an `installed_requires` dependency
* Add Travis CI support for python 2 + 3
* Update CHANGELOG.rst

Signed-off-by: Steven Esser <sesser@nexb.com>