### PR TITLE
Restrict python version for typing dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     requests >= 2.7.0, < 3.0.0
     intbitset >= 2.3.0, < 3.0
     saneyaml
-    typing >=3.6, < 3.7
+    typing >=3.6, < 3.7; python_version < "3.7"
 setup_requires = setuptools_scm[toml] >= 4
 
 [options.packages.find]


### PR DESCRIPTION
Importing typing causes errors after python 3.6.
See https://github.com/python/typing/issues/573