### PR TITLE
Remove encoding keyword argument

### DIFF
--- a/src/commoncode/resource.py
+++ b/src/commoncode/resource.py
@@ -1475,7 +1475,7 @@ class VirtualCodebase(Codebase):
             # to have support for caching at all?
             location = abspath(normpath(expanduser(location)))
             with io.open(location, 'rb') as f:
-                scan_data = json.load(f, object_pairs_hook=OrderedDict, encoding='utf-8')
+                scan_data = json.load(f, object_pairs_hook=OrderedDict)
             return scan_data
 
     def _get_scan_data(self, location):

--- a/src/commoncode/resource.py
+++ b/src/commoncode/resource.py
@@ -759,7 +759,7 @@ class Codebase(object):
             with open(cache_location, 'rb') as cached:
                 # TODO: Use custom json encoder to encode JSON list as a tuple
                 # TODO: Consider using simplejson
-                data = json.load(cached, object_pairs_hook=OrderedDict, encoding='utf-8')
+                data = json.load(cached, object_pairs_hook=OrderedDict)
                 return self.resource_class(**data)
         except Exception:
             with open(cache_location, 'rb') as cached:


### PR DESCRIPTION
Deprecated since Python version 3.1, removed in version 3.9

Signed-off-by: Thomas Druez <tdruez@nexb.com>