### PR TITLE
Support Click 8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ vNext
 -----
 
 
+Version 21.5.25
+---------------
+
+- Fix click-realted bug https://github.com/nexB/scancode-toolkit/issues/2529
+- Add tests to run on the latest of every dependency
+
+
 Version 21.5.12
 ---------------
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,3 @@
-
 ################################################################################
 # We use Azure to run the full tests suites on multiple Python 3.x
 # on multiple Windows, macOS and Linux versions all on 64 bits

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,3 +62,39 @@ jobs:
           python_versions: ['3.6', '3.7', '3.8', '3.9']
           test_suites:
               all: tmp\Scripts\pytest -n 2 -vvs
+
+
+################################################################################
+# Test using a plain pip install to get the latest of all wheels
+################################################################################
+
+
+    - template: etc/ci/azure-posix.yml
+      parameters:
+          job_name: ubuntu20_cpython_latest_from_pip
+          image_name: ubuntu-20.04
+          python_versions: ['3.6', '3.7', '3.8', '3.9']
+          test_suites:
+              all:
+                 - tmp/bin/pip --force-reinstall --upgrade -e .
+                 - tmp/bin/pytest -n 2 -vvs
+
+    - template: etc/ci/azure-win.yml
+      parameters:
+          job_name: win2019_cpython_latest_from_pip
+          image_name: windows-2019
+          python_versions: ['3.6', '3.7', '3.8', '3.9']
+          test_suites:
+              all:
+                 - tmp\Scripts\pip --force-reinstall --upgrade -e .
+                 - tmp\Scripts\pytest -n 2 -vvs
+
+    - template: etc/ci/azure-posix.yml
+      parameters:
+          job_name: macos1015_cpython_latest_from_pip
+          image_name: macos-10.15
+          python_versions: ['3.6', '3.7', '3.8', '3.9']
+          test_suites:
+              all:
+                 - tmp/bin/pip --force-reinstall --upgrade -e .
+                 - tmp/bin/pytest -n 2 -vvs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
           image_name: ubuntu-20.04
           python_versions: ['3.6', '3.7', '3.8', '3.9']
           test_suites:
-              all: tmp/bin/pip --force-reinstall --upgrade -e . && tmp/bin/pytest -n 2 -vvs
+              all: tmp/bin/pip install --force-reinstall --upgrade -e . && tmp/bin/pytest -n 2 -vvs
 
     - template: etc/ci/azure-win.yml
       parameters:
@@ -82,7 +82,7 @@ jobs:
           image_name: windows-2019
           python_versions: ['3.6', '3.7', '3.8', '3.9']
           test_suites:
-              all: tmp\Scripts\pip --force-reinstall --upgrade -e . &&  tmp\Scripts\pytest -n 2 -vvs
+              all: tmp\Scripts\pip install --force-reinstall --upgrade -e . &&  tmp\Scripts\pytest -n 2 -vvs
 
     - template: etc/ci/azure-posix.yml
       parameters:
@@ -90,4 +90,4 @@ jobs:
           image_name: macos-10.15
           python_versions: ['3.6', '3.7', '3.8', '3.9']
           test_suites:
-              all: tmp/bin/pip --force-reinstall --upgrade -e . && tmp/bin/pytest -n 2 -vvs
+              all: tmp/bin/pip install --force-reinstall --upgrade -e . && tmp/bin/pytest -n 2 -vvs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,9 +75,7 @@ jobs:
           image_name: ubuntu-20.04
           python_versions: ['3.6', '3.7', '3.8', '3.9']
           test_suites:
-              all:
-                 - tmp/bin/pip --force-reinstall --upgrade -e .
-                 - tmp/bin/pytest -n 2 -vvs
+              all: tmp/bin/pip --force-reinstall --upgrade -e . && tmp/bin/pytest -n 2 -vvs
 
     - template: etc/ci/azure-win.yml
       parameters:
@@ -85,9 +83,7 @@ jobs:
           image_name: windows-2019
           python_versions: ['3.6', '3.7', '3.8', '3.9']
           test_suites:
-              all:
-                 - tmp\Scripts\pip --force-reinstall --upgrade -e .
-                 - tmp\Scripts\pytest -n 2 -vvs
+              all: tmp\Scripts\pip --force-reinstall --upgrade -e . &&  tmp\Scripts\pytest -n 2 -vvs
 
     - template: etc/ci/azure-posix.yml
       parameters:
@@ -95,6 +91,4 @@ jobs:
           image_name: macos-10.15
           python_versions: ['3.6', '3.7', '3.8', '3.9']
           test_suites:
-              all:
-                 - tmp/bin/pip --force-reinstall --upgrade -e .
-                 - tmp/bin/pytest -n 2 -vvs
+              all: tmp/bin/pip --force-reinstall --upgrade -e . && tmp/bin/pytest -n 2 -vvs

--- a/src/commoncode/cliutils.py
+++ b/src/commoncode/cliutils.py
@@ -381,7 +381,6 @@ class PluggableCommandLineOption(click.Option):
             allow_from_autoenv=allow_from_autoenv,
             type=type,
             help=help,
-            hidden=hidden,
             **kwargs
         )
 
@@ -411,6 +410,11 @@ class PluggableCommandLineOption(click.Option):
         """
         _validate_option_dependencies(ctx, self, value, self.required_options, required=True)
         _validate_option_dependencies(ctx, self, value, self.conflicting_options, required=False)
+
+    def get_help_record(self, ctx):
+        if not self.hidden:
+            return click.Option.get_help_record(self, ctx)
+
 
 
 def validate_option_dependencies(ctx):

--- a/src/commoncode/cliutils.py
+++ b/src/commoncode/cliutils.py
@@ -352,6 +352,7 @@ class PluggableCommandLineOption(click.Option):
         allow_from_autoenv=True,
         type=None,  # NOQA
         help=None,  # NOQA
+        hidden=False,
         # custom additions #
         # a string that set the CLI help group for this option
         help_group=MISC_GROUP,
@@ -365,24 +366,22 @@ class PluggableCommandLineOption(click.Option):
         # a sequence of other option name strings that this option
         # conflicts with if they are set
         conflicting_options=(),
-        # a flag set to True if this option should be hidden from the CLI help
-        hidden=False,
         **kwargs
     ):
-
         super(PluggableCommandLineOption, self).__init__(
-            param_decls,
-            show_default,
-            prompt,
-            confirmation_prompt,
-            hide_input,
-            is_flag,
-            flag_value,
-            multiple,
-            count,
-            allow_from_autoenv,
-            type,
-            help,
+            param_decls=param_decls,
+            show_default=show_default,
+            prompt=prompt,
+            confirmation_prompt=confirmation_prompt,
+            hide_input=hide_input,
+            is_flag=is_flag,
+            flag_value=flag_value,
+            multiple=multiple,
+            count=count,
+            allow_from_autoenv=allow_from_autoenv,
+            type=type,
+            help=help,
+            hidden=hidden,
             **kwargs
         )
 
@@ -412,10 +411,6 @@ class PluggableCommandLineOption(click.Option):
         """
         _validate_option_dependencies(ctx, self, value, self.required_options, required=True)
         _validate_option_dependencies(ctx, self, value, self.conflicting_options, required=False)
-
-    def get_help_record(self, ctx):
-        if not self.hidden:
-            return click.Option.get_help_record(self, ctx)
 
 
 def validate_option_dependencies(ctx):

--- a/src/commoncode/cliutils.py
+++ b/src/commoncode/cliutils.py
@@ -9,7 +9,7 @@
 import sys
 
 import click
-click.disable_unicode_literals_warning = True
+
 from click.utils import echo
 from click.termui import style
 from click.types import BoolParamType

--- a/tests/test_cliutils.py
+++ b/tests/test_cliutils.py
@@ -138,8 +138,13 @@ class TestGroupedHelpCommand(FileDrivenTesting):
         from commoncode.cliutils import CORE_GROUP
 
         @click.command(name='scan', cls=GroupedHelpCommand)
-        @click.option('--opt', is_flag=True, help='Help text for option',
-                      help_group=CORE_GROUP, cls=PluggableCommandLineOption)
+        @click.option(
+            '--opt', 
+            is_flag=True, 
+            help='Help text for option',
+            help_group=CORE_GROUP, 
+            cls=PluggableCommandLineOption,
+        )
         def scan(opt):
             pass
 


### PR DESCRIPTION
In ScanCode, these
- https://github.com/nexB/scancode-toolkit/issues/2521
- https://github.com/nexB/scancode-toolkit/issues/2529
are reported as issues and are linked to the upgrade of Click when using a pypi pip install (without pinned requirements)
This fixes these issues
