### PR TITLE
Add preserve_spaces argument to portable_filename

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Release notes
 vNext
 -----
 
+- Add preserve_spaces argument in commoncode.paths.portable_filename.
+  This argument will prevent the replacement of spaces in filenames.
+
 
 Version 21.6.11
 ---------------
@@ -32,7 +35,7 @@ Version 21.5.12
 
 - Add new function to find a command or shared object file in the PATH (e.g. in
   environment variables). See commoncode.command.find_in_path()
-- Add new simplified the commoncode.command.execute() function. 
+- Add new simplified the commoncode.command.execute() function.
 - Add support for Python 3.10
 - Update tests to cope with Python 3.6 bug https://bugs.python.org/issue26919
 - Adopt latest skeleton with configure scripts updates

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -127,6 +127,10 @@ class TestPortablePath(TestCase):
         expected = 'A___file__with_Spaces.mov'
         assert paths.portable_filename("A:\\ file/ with Spaces.mov") == expected
 
+        # Test `preserve_spaces` option. Spaces should not be replaced
+        expected = 'Program Files (x86)'
+        assert paths.portable_filename("Program Files (x86)", preserve_spaces=True) == expected
+
         # Unresolved relative paths will be treated as a single filename. Use
         # resolve instead if you want to resolve paths:
         expected = '___.._.._etc_passwd'


### PR DESCRIPTION
This PR adds the `preserve_spaces` argument to `commoncode.paths.portable_filename`. When set to True,  `commoncode.paths.portable_filename` will not replace spaces in filenames.

Signed-off-by: Jono Yang <jyang@nexb.com>