### PR TITLE
Add output data format version to header

### DIFF
--- a/src/commoncode/resource.py
+++ b/src/commoncode/resource.py
@@ -154,6 +154,7 @@ class Header(object):
     notice = String(default='', help='Notice text for this tool.')
     start_timestamp = String(help='Start timestamp for this header.')
     end_timestamp = String(help='End timestamp for this header.')
+    output_format_version = String(help='Version for the scancode output data format, such as v1.1 .')
     duration = String(help='Scan duration in seconds.')
     message = String(help='Message text.')
     errors = List(help='List of error messages.')
@@ -175,6 +176,7 @@ class Header(object):
             'notice',
             'start_timestamp',
             'end_timestamp',
+            'output_format_version',
             'duration',
             'message',
             'errors',


### PR DESCRIPTION
Adds a new attribute `output_format_version` to the scancode header
to support output data format versioning.
See https://github.com/nexB/scancode-toolkit/issues/2653 for more details.

Signed-off-by: Ayan Sinha Mahapatra <ayansmahapatra@gmail.com>