### PR TITLE
Set minimal click version to 8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ python_requires = >=3.6.*, <4
 install_requires =
     attrs >= 18.1, !=20.1.0
     Beautifulsoup4 >= 4.0.0, < 5.0.0
-    click >= 6.7, !=7.0
+    click >= 8.0
     intbitset >= 2.3.0, < 3.0
     requests >= 2.7.0, < 3.0.0
     saneyaml >= 0.5.2


### PR DESCRIPTION
The pull request #27 adds `update_min_steps` option usage of `click._termui_impl.ProgressBar` that is available from click 8.0. But existed `setup.cfg` contains the following restriction: `click >= 6.7, !=7.0`. It breaks `scancode` with `click`<8 version installation. For example: https://github.com/ARMmbed/mbed-os/pull/14981/checks?check_run_id=3470879205

This pull request updates minimal `click` version in the `setup.cfg` according  changes in the pull request #27.
