### PR TITLE
Make safe filename safe to use on POSIX

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,14 @@
 Release notes
 =============
 
-Version (next) 
+Version (next)
 ------------------------------
 
-TBD.
+- Add ``posix_only`` option to ``commoncode.paths.portable_filename`` and
+  ``commoncode.paths.safe_path``. This option prevents
+  ``commoncode.paths.portable_filename`` and ``commoncode.paths.safe_path`` from
+  replacing filenames and punctuation in filenames that are valid on POSIX
+  operating systems, but not Windows.
 
 Version 31.0.0 - (2022-05-16)
 ------------------------------
@@ -50,7 +54,7 @@ This is a major version with API-breaking changes in the resource module.
   otherwise missing from files path list.
   In particular this behaviour changed when you create a VirtualCodebase from
   a previous Codebase created with a "full_root" argument. Previously, the
-  missing paths of a "full_root" Codebase were kept unchanged. 
+  missing paths of a "full_root" Codebase were kept unchanged.
   Note that the VirtualCodebase has always ignored the "full_root" argument.
 
 - The Codebase and VirtualCodebase are now iterable. Iterating on a codebase
@@ -80,7 +84,7 @@ Other changes:
 
 - Remove Python upper version limit.
 - Merge latest skeleton
-- fileutils.parent_directory() now accepts a "with_trail" argument. 
+- fileutils.parent_directory() now accepts a "with_trail" argument.
   The returned directory has a trailing path separator unless with_trail is False.
   The default is True and the default behaviour is unchanged.
 

--- a/src/commoncode/paths.py
+++ b/src/commoncode/paths.py
@@ -26,7 +26,7 @@ to OS-safe paths and to POSIX paths.
 # Build OS-portable and safer paths
 
 
-def safe_path(path, posix=False, preserve_spaces=False):
+def safe_path(path, posix=False, preserve_spaces=False, posix_only=False):
     """
     Convert `path` to a safe and portable POSIX path usable on multiple OSes.
     The returned path is an ASCII-only byte string, resolved for relative
@@ -52,7 +52,13 @@ def safe_path(path, posix=False, preserve_spaces=False):
     _pathmod, path_sep = path_handlers(path, posix)
 
     segments = [s.strip() for s in path.split(path_sep) if s.strip()]
-    segments = [portable_filename(s, preserve_spaces=preserve_spaces) for s in segments]
+    segments = [
+        portable_filename(
+            s,
+            preserve_spaces=preserve_spaces,
+            posix_only=posix_only
+        ) for s in segments
+    ]
 
     if not segments:
         return '_'

--- a/src/commoncode/paths.py
+++ b/src/commoncode/paths.py
@@ -198,6 +198,40 @@ def portable_filename(filename, preserve_spaces=False):
 
     return filename
 
+
+posix_legal_punctuation = r"!@#$%^&\*\(\)-_=\+\[\{\]\}\\\|;:'\",<.>\/\?`~\ "
+posix_legal_characters = r"A-Za-z0-9" + posix_legal_punctuation
+posix_illegal_characters_re = r"[^" + posix_legal_characters + r"]"
+replace_illegal_posix_chars = re.compile(posix_illegal_characters_re).sub
+
+
+def posix_safe_filename(filename):
+    """
+    Return a new name for `filename` that is portable across POSIX systems.
+
+    Filenames returned by `posix_safe_filename` are not guarenteed to be valid
+    on Windows systems as they may contain characters not allowed in Windows
+    filenames.
+    """
+    filename = toascii(filename, translit=True)
+
+    if not filename:
+        return '_'
+
+    filename = replace_illegal_posix_chars('_', filename)
+
+    # no name made only of dots.
+    if set(filename) == set(['.']):
+        filename = 'dot' * len(filename)
+
+    # replaced any leading dotdot
+    if filename != '..' and filename.startswith('..'):
+        while filename.startswith('..'):
+            filename = filename.replace('..', '__', 1)
+
+    return filename
+
+
 #
 # paths comparisons, common prefix and suffix extraction
 #

--- a/src/commoncode/paths.py
+++ b/src/commoncode/paths.py
@@ -140,9 +140,10 @@ def resolve(path, posix=True):
     return path
 
 
-legal_punctuation = r"!\#$%&\(\)\+,\-\.;\=@\[\]_\{\}\~"
-legal_spaces = r" "
-legal_chars = r'A-Za-z0-9' + legal_punctuation
+legal_punctuation = r'!\#$%&\(\)\+,\-\.;\=@\[\]_\{\}\~'
+legal_spaces = r' '
+legal_alphanumeric = r'A-Za-z0-9'
+legal_chars = legal_alphanumeric + legal_punctuation
 legal_chars_inc_spaces = legal_chars + legal_spaces
 illegal_chars_re = r'[^' + legal_chars + r']'
 illegal_chars_exc_spaces_re = r'[^' + legal_chars_inc_spaces + r']'
@@ -150,13 +151,20 @@ replace_illegal_chars = re.compile(illegal_chars_re).sub
 replace_illegal_chars_exc_spaces = re.compile(illegal_chars_exc_spaces_re).sub
 
 
-posix_legal_punctuation = r"!@#$%^&\*\(\)-_=\+\[\{\]\}\\\|;:'\",<.>\/\?`~"
-posix_legal_chars = r"A-Za-z0-9" + posix_legal_punctuation
+posix_legal_punctuation = r'<:"/>\|\*\^\\\'`\?' + legal_punctuation
+posix_legal_chars = legal_alphanumeric + posix_legal_punctuation
 posix_legal_chars_inc_spaces = posix_legal_chars + legal_spaces
-posix_illegal_chars_re = r"[^" + posix_legal_chars + r"]"
-posix_illegal_chars_exc_spaces_re = r"[^" + posix_legal_chars_inc_spaces + r"]"
+posix_illegal_chars_re = r'[^' + posix_legal_chars + r']'
+posix_illegal_chars_exc_spaces_re = r'[^' + posix_legal_chars_inc_spaces + r']'
 replace_illegal_posix_chars = re.compile(posix_illegal_chars_re).sub
 replace_illegal_posix_chars_exc_spaces = re.compile(posix_illegal_chars_exc_spaces_re).sub
+
+
+ILLEGAL_WINDOWS_NAMES = set([
+    'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
+    'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9',
+    'aux', 'con', 'nul', 'prn'
+])
 
 
 def portable_filename(filename, preserve_spaces=False, posix_only=False):
@@ -197,16 +205,8 @@ def portable_filename(filename, preserve_spaces=False, posix_only=False):
             filename = replace_illegal_chars('_', filename)
 
     if not posix_only:
-        # these are illegal both upper and lowercase and with or without an extension
-        # we insert an underscore after the base name.
-        windows_illegal_names = set([
-            'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9',
-            'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9',
-            'aux', 'con', 'nul', 'prn'
-        ])
-
         basename, dot, extension = filename.partition('.')
-        if basename.lower() in windows_illegal_names:
+        if basename.lower() in ILLEGAL_WINDOWS_NAMES:
             filename = ''.join([basename, '_', dot, extension])
 
     # no name made only of dots.


### PR DESCRIPTION
This enables handling safe paths treating some extra characters as safe on POSIX.
In particular this ensures that we can treat the colon ":" as safe for use in file names
on POSIX only. This will allow correct processing of system files in ScanCode.io
and ExtractCode

Reference: https://github.com/nexB/extractcode/issues/41
Reference: https://github.com/nexB/scancode.io/issues/407
Reference: https://github.com/nexB/scancode.io/issues/445