### PR TITLE
Fix virtualcodebase creation bug

### DIFF
--- a/src/commoncode/resource.py
+++ b/src/commoncode/resource.py
@@ -2034,12 +2034,13 @@ class VirtualCodebase(Codebase):
 
         current = self.root
         for segment in path_segments:
-            existing = resources_by_path.get(segment)
+            path = posixpath_join(current.path, segment)
+            existing = resources_by_path.get(path)
             if not existing:
                 existing = self._get_or_create_resource(
                     name=segment,
                     # build the path based on parent
-                    path=posixpath_join(current.path, segment),
+                    path=path,
                     parent=current,
                     is_file=False,
                 )

--- a/src/commoncode/resource.py
+++ b/src/commoncode/resource.py
@@ -2036,7 +2036,7 @@ class VirtualCodebase(Codebase):
         for segment in path_segments:
             path = posixpath_join(current.path, segment)
             existing = resources_by_path.get(path)
-            if not existing:
+            if not existing or existing == Codebase.CACHED_RESOURCE:
                 existing = self._get_or_create_resource(
                     name=segment,
                     # build the path based on parent

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1451,6 +1451,28 @@ class TestVirtualCodebaseCreation(FileBasedTesting):
         test_file = self.get_test_loc('resource/virtual_codebase/zephyr-binary.json')
         VirtualCodebase(test_file)
 
+    def test_VirtualCodebase_can_be_created_with_repeated_root_directory(self):
+        paths = [
+            'to',
+            'to/to',
+            'to/to/com.liferay.portal.tika-1.0.22.jar',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay/portal',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay/portal/tika',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay/portal/tika/internal',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay/portal/tika/internal/activator',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay/portal/tika/internal/activator/TikaBundleActivator.class',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/META-INF',
+            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/META-INF/MANIFEST.MF',
+        ]
+        resources = [{'path': path} for path in paths]
+        vc = VirtualCodebase(location={'files': resources})
+        walked_paths = [r.path for r in vc.walk()]
+        assert paths == walked_paths
+
 
 class TestResource(FileBasedTesting):
     test_data_dir = join(dirname(__file__), 'data')

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1455,18 +1455,8 @@ class TestVirtualCodebaseCreation(FileBasedTesting):
         paths = [
             'to',
             'to/to',
-            'to/to/com.liferay.portal.tika-1.0.22.jar',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay/portal',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay/portal/tika',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay/portal/tika/internal',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay/portal/tika/internal/activator',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/com/liferay/portal/tika/internal/activator/TikaBundleActivator.class',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/META-INF',
-            'to/to/com.liferay.portal.tika-1.0.22.jar-extract/com.liferay.portal.tika-1.0.22/META-INF/MANIFEST.MF',
+            'to/to/to',
+            'to/to/to/to',
         ]
         resources = [{'path': path} for path in paths]
         vc = VirtualCodebase(location={'files': resources})


### PR DESCRIPTION
This PR fixes a bug in VirtualCodebase creation where in the case where the immediate child of the root has the same directory name as the root would cause us to prevent us from creating the codebase tree properly.