### PR TITLE
Fix Deprecation Warning in timeutils.py and archive.py (#75)

### DIFF
--- a/src/commoncode/archive.py
+++ b/src/commoncode/archive.py
@@ -62,7 +62,10 @@ def extract_tar(location, target_dir, verbatim=False, filter=None, *args, **kwar
             if py314 and filter:
                 tar.extractall(target_dir, members=to_extract, filter=filter)
             else:
-                tar.extractall(target_dir, members=to_extract)
+                try:
+            tar.extractall(target_dir, members=to_extract, filter='data')
+        except TypeError:
+            tar.extractall(target_dir, members=to_extract)
         finally:
             if tar:
                 tar.close()

--- a/src/commoncode/timeutils.py
+++ b/src/commoncode/timeutils.py
@@ -59,7 +59,7 @@ def time2tstamp(dt=None, path_safe=True):
     to convert back to a datetime object.
     """
     # TODO: check that the dt is effectively in UTC
-    datim = dt or datetime.now(timezone.utc)
+    datim = dt or datetime.now(timezone.utc).replace(tzinfo=None)
     iso = datim.isoformat()
     if path_safe:
         iso = iso.replace(":", "").replace("/", "_")

--- a/src/commoncode/timeutils.py
+++ b/src/commoncode/timeutils.py
@@ -7,6 +7,7 @@
 #
 
 from datetime import datetime
+from datetime import timezone
 from datetime import tzinfo
 from functools import update_wrapper
 from functools import wraps
@@ -58,7 +59,7 @@ def time2tstamp(dt=None, path_safe=True):
     to convert back to a datetime object.
     """
     # TODO: check that the dt is effectively in UTC
-    datim = dt or datetime.utcnow()
+    datim = dt or datetime.now(timezone.utc)
     iso = datim.isoformat()
     if path_safe:
         iso = iso.replace(":", "").replace("/", "_")


### PR DESCRIPTION
Fixes #75

Changes:
1. Replace `datetime.utcnow()` with `datetime.now(timezone.utc)` in `timeutils.py`
  (deprecated since Python 3.12, scheduled for removal in Python 3.14+)

2. Add `filter='data'` to `tar.extractall()` in `archive.py` with fallback
  for Python < 3.12 (Python 3.14 will default to filtering tar archives)