### PR TITLE
Fix double-increment of progress bar position in DebuggedProgressBar.make_step

### DIFF
--- a/src/commoncode/cliutils.py
+++ b/src/commoncode/cliutils.py
@@ -194,9 +194,8 @@ class DebuggedProgressBar(CompatProgressBar):
     # overriden and copied from Click to work around Click woes for
     # https://github.com/aboutcode-org/scancode-toolkit/issues/2583
     def make_step(self, n_steps):
-        # always increment
-        self.pos += n_steps or 1
-        super(DebuggedProgressBar, self).make_step(n_steps)
+        # always increment even if n_steps is 0
+        super(DebuggedProgressBar, self).make_step(n_steps or 1)
 
     # overriden and copied from Click to work around Click woes for
     # https://github.com/aboutcode-org/scancode-toolkit/issues/2583


### PR DESCRIPTION
make_step was incrementing self.pos manually and then calling super().make_step() which incremented it again, causing the progress bar to advance twice as fast as expected.

Related to: https://github.com/aboutcode-org/scancode-toolkit/pull/4100

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>