### PR TITLE
Replace production assert with explicit TypeError (one issue)

### DIFF
--- a/src/commoncode/text.py
+++ b/src/commoncode/text.py
@@ -142,5 +142,8 @@ def as_unicode(s):
         return ""
     if not s:
         return s
-    assert isinstance(s, bytes), "s must be bytes but is: {}".format(s)
+
+    if not isinstance(s, bytes):
+        raise TypeError(f"s must be bytes but is: {type(s).__name__}")
+
     return UnicodeDammit(s).unicode_markup

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -92,5 +92,5 @@ def test_as_unicode():
     try:
         text.as_unicode(["foo"])
         raise Exception("Exception should have been raised")
-    except AssertionError:
+    except TypeError:
         pass


### PR DESCRIPTION
Fixes part of aboutcode-org/aboutcode#175

This PR replaces a production assert in commoncode.text.as_unicode() with an explicit TypeError.

Changes:
- Replaces runtime assert with TypeError
- Updates related test expectation from AssertionError to TypeError
- Leaves pytest/test asserts unchanged

Test:
PYTHONPATH=src python3 -m pytest tests/test_text.py