### PR TITLE
Replace fileset production asserts with explicit exceptions

### DIFF
--- a/src/commoncode/fileset.py
+++ b/src/commoncode/fileset.py
@@ -119,7 +119,9 @@ def get_matches(path, patterns, all_matches=False):
 
     matches = []
     if not isinstance(patterns, dict):
-        assert isinstance(patterns, (list, tuple)), "Invalid patterns: {}".format(patterns)
+        if not isinstance(patterns, (list, tuple)):
+            raise TypeError("Invalid patterns: {}".format(patterns))
+
         patterns = {p: p for p in patterns}
 
     for pat, value in patterns.items():
@@ -158,7 +160,8 @@ def load(location):
         return tuple()
     fn = os.path.abspath(os.path.normpath(os.path.expanduser(location)))
     msg = ("File %(location)s does not exist or not a file.") % locals()
-    assert os.path.exists(fn) and os.path.isfile(fn), msg
+    if not os.path.exists(fn) or not os.path.isfile(fn):
+         raise FileNotFoundError(msg)
     mode = "r"
     with open(fn, mode) as f:
         return [line.strip() for line in f if line and line.strip()]


### PR DESCRIPTION
Contributes to aboutcode-org/aboutcode#175

This PR replaces production assert statements in `commoncode/fileset.py` with explicit runtime exceptions.

Changes:

* Replaced `assert isinstance(patterns, (list, tuple))` with `TypeError`
* Replaced file existence assert with `FileNotFoundError`
* Kept pytest/test asserts unchanged

Why:
Production asserts can be skipped when Python is run with optimization flags (`-O` / `-OO`). Explicit exceptions ensure runtime validation is preserved consistently.

Tested with:
PYTHONPATH=src python3 -m pytest tests/test_fileset.py
