### PR TITLE
Replace command production assert with explicit exception

### DIFF
--- a/src/commoncode/command.py
+++ b/src/commoncode/command.py
@@ -58,7 +58,8 @@ def execute(cmd_loc, args, cwd=None, env=None, to_files=False, log=TRACE):
     Run the command using the `cwd` current working directory with an `env` dict
     of environment variables.
     """
-    assert cmd_loc
+    if not cmd_loc:
+        raise FileNotFoundError(f"Unable to find command: {cmd}")
     full_cmd = [cmd_loc] + (args or [])
 
     # any shared object should be either in the PATH, the rpath or


### PR DESCRIPTION
Contributes to aboutcode-org/aboutcode#175

This PR replaces a production assert in `commoncode/command.py` with an explicit runtime exception.

Changes:

* Replaced `assert cmd_loc` with `FileNotFoundError`
* Kept pytest/test asserts unchanged

Why:
Production asserts can be skipped when Python is run with optimization flags (`-O` / `-OO`). Explicit exceptions ensure runtime validation is preserved consistently.

Tested with:
PYTHONPATH=src python3 -m pytest tests/test_command.py