### PR TITLE
Handle removing resources without parents

### DIFF
--- a/src/commoncode/resource.py
+++ b/src/commoncode/resource.py
@@ -906,8 +906,9 @@ class Codebase:
         parent = resource.parent(self)
         if TRACE:
             logger_debug("    parent", parent)
-        parent.children_names.remove(resource.name)
-        parent.save(self)
+        if parent:
+            parent.children_names.remove(resource.name)
+            parent.save(self)
 
         # remove resource proper
         self._remove_resource(resource)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -101,6 +101,19 @@ class TestCodebase(FileBasedTesting):
         ]
         assert [(r.name, r.is_file) for r in results] == expected
 
+    def test_remove_resource_without_parent(self):
+        test_codebase = self.get_test_loc("resource/codebase")
+        codebase = Codebase(test_codebase)
+        resource = codebase.get_resource("codebase/dir/that")
+        parent = resource.parent(codebase)
+
+        codebase.resources_by_path.pop(parent.path)
+
+        removed_paths = codebase.remove_resource(resource)
+
+        assert removed_paths == {resource.location}
+        assert resource.path not in codebase.resources_by_path
+
     def test_walk_filtered_with_filtered_root(self):
         test_codebase = self.get_test_loc("resource/codebase")
         codebase = Codebase(test_codebase)


### PR DESCRIPTION
Summary:
- Skip parent child-list updates when the resource parent is no longer present in the codebase.
- Keep removing the requested resource and its descendants in that parentless case.
- Add a regression covering removal after the parent resource is missing.

Fixes: #84

Validation:
- git diff --check
- git diff --check HEAD~1..HEAD
- Not run locally